### PR TITLE
Fix for "find" when iterating folders without permission

### DIFF
--- a/sbin/zz-mainline-signing
+++ b/sbin/zz-mainline-signing
@@ -46,7 +46,7 @@ fi
 
 echo "Finding matching Ubuntu mainline kernels"
 cd /
-KERNEL_IMG_DEB=$(find /home /root -name "*image-unsigned-${KERNEL_VERSION}*.deb")
+KERNEL_IMG_DEB=$(find /home /root -name "*image-unsigned-${KERNEL_VERSION}*.deb" 2> /dev/null ; exit 0)
 
 echo "Checking if there is more than one or no matching kernel deb files"
 if (($(echo "$KERNEL_IMG_DEB" | wc -l) < 1)); then
@@ -152,3 +152,4 @@ else
     " >&2
     exit 1
 fi
+


### PR DESCRIPTION
When "find" is used to look for the mainline debian package, it looks in /home and /root. If there is any folder where find has no permission to look into (e.g. 'thinclient_drives' when using xrdp), the command will fail.

This is because 'find' will return with code 1 when there is any error (related or not).
This patch will first discard all errors written on stderr (send it to /dev/null) and second will always return 0 exit code to prevent the script from failing.

The exit code is not relevant in this case because the result of found mainline-kernel packages is checked (has to be exactly 1 result). If there are more (or no) matches, script will still fail.